### PR TITLE
Ensure promotions are only create if the order is present

### DIFF
--- a/core/app/models/spree/promotion/actions/create_line_items.rb
+++ b/core/app/models/spree/promotion/actions/create_line_items.rb
@@ -37,7 +37,7 @@ module Spree
         # needs to be manually removed from the order by the customer
         def perform(options = {})
           order = options[:order]
-          return unless self.eligible? order
+          return false unless order.present? && self.eligible?(order)
 
           promotion_action_line_items.each do |item|
             current_quantity = order.quantity_of(item.variant)

--- a/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
+++ b/core/spec/models/spree/promotion/actions/create_line_items_spec.rb
@@ -20,6 +20,12 @@ describe Spree::Promotion::Actions::CreateLineItems, :type => :model do
       )
     end
 
+    context "order is nil" do
+      it "returns false" do
+        expect(action.perform(order: nil)).to eq(false)
+      end
+    end
+
     context "order is eligible" do
       before do
         allow(promotion).to receive_messages :eligible => true


### PR DESCRIPTION
@evanwhalen 

For some reason the usual test for false-ness (`be_false`) wasn't working.