### PR TITLE
Bump Active Merchant To 1.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The following pull requests affect functionality above and will need to be addre
 
 - [ ] Undo HTTP Patch of order, https://github.com/spree/spree/pull/5946
 
+The following changes will not be accepted into Spree
+
+- [ ] Bump ActiveMerchant to 1.49.
+
 SUMMARY
 -------
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following pull requests affect functionality above and will need to be addre
 
 The following changes will not be accepted into Spree
 
-- [ ] Bump ActiveMerchant to 1.49.
+- [ ] Bump ActiveMerchant to 1.52.
 
 SUMMARY
 -------

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.44.1'
+  s.add_dependency 'activemerchant', '~> 1.49.0'
   s.add_dependency 'acts_as_list', '= 0.3.0'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
   s.add_dependency 'aws-sdk', '1.27.0'

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files        = Dir['LICENSE', 'README.md', 'app/**/*', 'config/**/*', 'lib/**/*', 'db/**/*', 'vendor/**/*']
   s.require_path = 'lib'
 
-  s.add_dependency 'activemerchant', '~> 1.49.0'
+  s.add_dependency 'activemerchant', '~> 1.52.0'
   s.add_dependency 'acts_as_list', '= 0.3.0'
   s.add_dependency 'awesome_nested_set', '~> 3.0.0.rc.3'
   s.add_dependency 'aws-sdk', '1.27.0'


### PR DESCRIPTION
Active Merchant 1.49 supports the destination parameter in Stripe.

We'll need to upgrade if we are to successfully change Spree::Gateway to allow us to support a destination on a Stripe payment.

/cc @paololim 