### PR TITLE
removed tax code for spree_avatax_certified

### DIFF
--- a/backend/app/views/spree/admin/tax_categories/_form.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/_form.html.erb
@@ -6,13 +6,6 @@
     <% end %>
   </div>
 
-  <div class="two columns">
-    <%= f.field_container :tax_code do %>
-      <%= f.label :tax_code, Spree.t(:tax_code) %>
-      <%= f.text_field :tax_code, :class => 'fullwidth' %>
-    <% end %>
-  </div>
-  
   <div class="five columns">
     <%= f.field_container :description do %>
       <%= f.label :description, Spree.t(:description) %><br>

--- a/backend/app/views/spree/admin/tax_categories/index.html.erb
+++ b/backend/app/views/spree/admin/tax_categories/index.html.erb
@@ -24,7 +24,6 @@
   <thead>
     <tr data-hook="tax_header">
       <th><%= Spree.t(:name) %></th>
-      <th><%= Spree.t(:tax_code) %></th>
       <th><%= Spree.t(:description) %></th>
       <th><%= Spree.t(:default) %></th>
       <th class="actions"></th>
@@ -37,7 +36,6 @@
     %>
       <tr id="<%= spree_dom_id tax_category %>" data-hook="tax_row" class="<%= cycle('odd', 'even')%>">
         <td class="align-center"><%= tax_category.name %></td>
-        <td class="align-center"><%= tax_category.tax_code %></td>
         <td class="align-center"><%= tax_category.description %></td>
         <td class="align-center"><%= tax_category.is_default? ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>
         <td class="actions">

--- a/backend/spec/controllers/spree/admin/tax_categories_controller_spec.rb
+++ b/backend/spec/controllers/spree/admin/tax_categories_controller_spec.rb
@@ -15,8 +15,8 @@ module Spree
 
       describe 'PUT #update' do
         let(:tax_category) { create :tax_category }
-    
-        subject { spree_put :update, {id: tax_category.id, tax_category: { name: 'Foo', tax_code: 'Bar' }}}
+
+        subject { spree_put :update, {id: tax_category.id, tax_category: { name: 'Foo', description: 'Bar' }}}
 
         it 'should redirect' do
           expect(subject).to be_redirect
@@ -26,7 +26,7 @@ module Spree
           subject
           tax_category.reload
           expect(tax_category.name).to eq('Foo')
-          expect(tax_category.tax_code).to eq('Bar')
+          expect(tax_category.description).to eq('Bar')
         end
       end
     end

--- a/backend/spec/features/admin/configuration/tax_categories_spec.rb
+++ b/backend/spec/features/admin/configuration/tax_categories_spec.rb
@@ -10,7 +10,7 @@ describe "Tax Categories", :type => :feature do
 
   context "admin visiting tax categories list" do
     it "should display the existing tax categories" do
-      create(:tax_category, :name => "Clothing", :tax_code => "CL001", :description => "For Clothing")
+      create(:tax_category, :name => "Clothing", :description => "For Clothing")
       click_link "Tax Categories"
       expect(page).to have_content("Listing Tax Categories")
       within_row(1) do


### PR DESCRIPTION
On blueapron-marketplace, we are going to be installing the gem spree_avatax_certified and removing spree_avatax. spree_avatax_certified branch 2-3-stable gets the tax code from description, since in spree 2-3-stable, there was no tax_code column. In this PR, I remove all references to tax_code.