### PR TITLE
Bump Paper Clip, Green Tests

### DIFF
--- a/core/spec/models/spree/credit_card_spec.rb
+++ b/core/spec/models/spree/credit_card_spec.rb
@@ -4,7 +4,7 @@ describe Spree::CreditCard, :type => :model do
   let(:valid_credit_card_attributes) do
     { :number => '4111111111111111',
       :verification_value => '123',
-      :expiry => "12 / 14",
+      :expiry => "12 / #{(Time.now.year + 1).to_s[2..3]}",
       :name => "Spree Commerce" }
   end
 

--- a/core/spec/models/spree/order_spec.rb
+++ b/core/spec/models/spree/order_spec.rb
@@ -191,7 +191,7 @@ describe Spree::Order, :type => :model do
     context 'when variant is destroyed' do
       before do
         allow(order).to receive(:restart_checkout_flow)
-        order.line_items.first.variant.destroy
+        allow_any_instance_of(Spree::Variant).to receive(:destroyed?) { true }
       end
 
       it 'should restart checkout flow' do

--- a/core/spec/models/spree/payment_spec.rb
+++ b/core/spec/models/spree/payment_spec.rb
@@ -13,7 +13,7 @@ describe Spree::Payment, :type => :model do
     Spree::CreditCard.create!(
       number: "4111111111111111",
       month: "12",
-      year: "2014",
+      year: Time.now.year + 1,
       verification_value: "123",
       name: "Name",
       imported: false
@@ -173,8 +173,7 @@ describe Spree::Payment, :type => :model do
       end
 
       it "should log the response" do
-        expect(payment.log_entries).to receive(:create!).with(:details => anything)
-        payment.authorize!
+        expect { payment.authorize! }.to change { Spree::LogEntry.count }.by(1)
       end
 
       context "when gateway does not match the environment" do
@@ -224,8 +223,7 @@ describe Spree::Payment, :type => :model do
       end
 
       it "should log the response" do
-        expect(payment.log_entries).to receive(:create!).with(:details => anything)
-        payment.purchase!
+        expect { payment.purchase! }.to change { Spree::LogEntry.count }.by(1)
       end
 
       context "when gateway does not match the environment" do
@@ -451,8 +449,7 @@ describe Spree::Payment, :type => :model do
       end
 
       it "should log the response" do
-        expect(payment.log_entries).to receive(:create!).with(:details => anything)
-        payment.credit!
+        expect { payment.credit! }.to change { Spree::LogEntry.count }.by(1)
       end
 
       context "when gateway does not match the environment" do
@@ -613,7 +610,7 @@ describe Spree::Payment, :type => :model do
 
       context "when there is an error connecting to the gateway" do
         it "should call gateway_error " do
-          expect(gateway).to receive(:create_profile).and_raise(ActiveMerchant::ConnectionError)
+          expect(gateway).to receive(:create_profile).and_raise(ActiveMerchant::ConnectionError.new(double, double))
           expect do
             Spree::Payment.create(
               :amount => 100,
@@ -631,7 +628,7 @@ describe Spree::Payment, :type => :model do
 
           order.payments.create!(source_attributes: {number: "4111111111111115",
                                                     month: "12",
-                                                    year: "2014",
+                                                    year: Time.now.year + 1,
                                                     verification_value: "123",
                                                     name: "Name"
           },
@@ -641,7 +638,7 @@ describe Spree::Payment, :type => :model do
           expect(order.payments.count).to eq(1)
           order.payments.create!(source_attributes: {number: "4111111111111111",
                                                     month: "12",
-                                                    year: "2014",
+                                                    year: Time.now.year + 1,
                                                     verification_value: "123",
                                                     name: "Name"
           },

--- a/core/spree_core.gemspec
+++ b/core/spree_core.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json', '~> 1.7'
   s.add_dependency 'kaminari', '~> 0.15', '>= 0.15.1'
   s.add_dependency 'monetize'
-  s.add_dependency 'paperclip', '~> 4.2.0'
+  s.add_dependency 'paperclip', '~> 4.3.6'
   s.add_dependency 'paranoia', '~> 2.0'
   s.add_dependency 'rails', '~> 4.1.6'
   s.add_dependency 'ransack', '~> 1.4.1'


### PR DESCRIPTION
This PR accomplishes two things.

1) It bumps Paper Clip gem due to a security alert.
2) We no longer have green tests for Spree Core due to weird mocks, weird hard coded CC years, etc.

<img width="616" alt="screen shot 2016-03-15 at 3 51 45 pm" src="https://cloud.githubusercontent.com/assets/134368/13796438/1fd00b32-eadd-11e5-9e14-b5556b299073.png">

<img width="1248" alt="screen shot 2016-03-15 at 6 34 30 pm" src="https://cloud.githubusercontent.com/assets/134368/13796472/489e9222-eadd-11e5-8092-3ea77c92ed28.png">

/cc @prsimp for security
/cc @dylandrop who informed me Spree is around longer
/cc @evanwhalen for Spree awareness