### PR TITLE
Ensure order is properly updated after payment change.

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -193,18 +193,8 @@ module Spree
       end
 
       def update_order
-        if self.completed?
-          order.updater.update_payment_total
-        end
-
-        if order.completed?
-          order.updater.update_payment_state
-          order.updater.update_shipments
-          order.updater.update_shipment_state
-        end
-
-        if self.completed? || order.completed?
-          order.persist_totals
+        if order.completed? || completed? || void?
+          order.update!
         end
       end
 


### PR DESCRIPTION
This is a cherry-pick from solidusio/solidus@a1dd8582. Although that commit's goals is better encapsulation, our need here is driven from the fact that after voiding a payment the order payment_state and payment_total is not updated.

Although the existing Spree code does update those two fields, because of the selective use of OrderUpdater it doesn't actually persist the values to the DB because it only does that if the payment is complete.

Obviously a bug but rather than fix that bug we just follow the example of Solidus and let the OrderUpdater be responsible for updating the order. It does it correctly leaving this code simpler.